### PR TITLE
Metadata Merge Path Fix

### DIFF
--- a/src/commands/meta/merge.js
+++ b/src/commands/meta/merge.js
@@ -26,6 +26,6 @@ exports.handler = async (argv) => {
 
     await davos.merge();
   } else {
-    Log.error('Please provide in and out params: --in "path/to/file.xml" --out "output/folder"');
+    Log.error('Please provide in and out params: --in "path/to/splitted/meta" --out "output/folder/filename.xml"');
   }
 };

--- a/src/commands/meta/merge.js
+++ b/src/commands/meta/merge.js
@@ -26,6 +26,6 @@ exports.handler = async (argv) => {
 
     await davos.merge();
   } else {
-    Log.error('Please provide in and out params: --in "path/to/splitted/meta" --out "output/folder/filename.xml"');
+    Log.error('Please provide in and out params: --in "path/to/split/meta" --out "output/folder/filename.xml"');
   }
 };

--- a/src/tasks/meta.merge.js
+++ b/src/tasks/meta.merge.js
@@ -25,7 +25,7 @@ async function merge(paramIn, paramOut, force, config) {
         });
     }
 
-    pattern = path.join(root, config.command.in);
+    pattern = path.join(root, config.command.in).replace(/\\/g, '/');
     out = config.command.out;
     outPath = path.join(root, out);
     outWithoutFile = outPath.substring(0, outPath.lastIndexOf(path.sep));


### PR DESCRIPTION
-Fixed issue with backslashes, causing no output when the merge command is executed
-Fixed the comment when missing arguments are provided for the merge task